### PR TITLE
Fix readme typo

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -304,7 +304,7 @@ Watches the whole config object, calling `callback` on any changes.
 Returns a function which you can use to unsubscribe:
 
 ```js
-const unsubscribe = store.onDidAnyChange(key, callback);
+const unsubscribe = store.onDidAnyChange(callback);
 
 unsubscribe();
 ```


### PR DESCRIPTION
As mentioned in #136, this fixes a typo in the example code for onDidAnyChange.